### PR TITLE
Refactor LuaJIT-specific unpack path into its own helper

### DIFF
--- a/src/unpack.c
+++ b/src/unpack.c
@@ -33,14 +33,63 @@
 # define unpack_rawlen(L, idx) lua_rawlen((L), (idx))
 #endif
 
-#if LUA_VERSION_NUM >= 503
-# define unpack_isinteger(L, idx) lua_isinteger((L), (idx))
-#else
+#if defined(LUA_LJDIR)
+
 static inline int unpack_isinteger(lua_State *L, int idx)
 {
     return lua_type(L, idx) == LUA_TNUMBER &&
            (lua_Number)lua_tointeger(L, idx) == lua_tonumber(L, idx);
 }
+
+static inline int unpack_lj(lua_State *L, lua_Integer i)
+{
+    unsigned int n = 0;
+    lua_State *th  = lua_newthread(L);
+
+    lua_insert(L, 1);
+    lua_settop(L, 2);
+    lua_pushnil(L);
+    while (lua_next(L, 2)) {
+        if (unpack_isinteger(L, -2)) {
+            int top         = lua_gettop(th);
+            lua_Integer idx = lua_tointeger(L, -2);
+
+            // ignore index less than i
+            if (idx < i) {
+                lua_pop(L, 1);
+                continue;
+            }
+
+            // calculate target index on new stack
+            idx = idx - i + 1;
+            if (idx > top && !lua_checkstack(th, idx - top)) {
+                return luaL_error(L, "too many results to unpack");
+            } else if (idx <= top) {
+                lua_xmove(L, th, 1);
+                lua_replace(th, idx);
+                continue;
+            }
+
+            // fill nils for missing indexes
+            for (int j = top + 1; j < idx; j++) {
+                lua_pushnil(th);
+            }
+            lua_xmove(L, th, 1);
+            continue;
+        }
+        lua_pop(L, 1);
+    }
+
+    // return results
+    lua_settop(L, 1);
+    n = lua_gettop(th);
+    if (!lua_checkstack(L, n)) {
+        return luaL_error(L, "too many results to unpack");
+    }
+    lua_xmove(th, L, n);
+    return (int)n;
+}
+
 #endif
 
 static int unpack_lua(lua_State *L)
@@ -55,50 +104,7 @@ static int unpack_lua(lua_State *L)
 
 #if defined(LUA_LJDIR)
     if (lua_isnoneornil(L, 3)) {
-        lua_State *th = lua_newthread(L);
-
-        lua_insert(L, 1);
-        lua_settop(L, 2);
-        lua_pushnil(L);
-        while (lua_next(L, 2)) {
-            if (unpack_isinteger(L, -2)) {
-                int top         = lua_gettop(th);
-                lua_Integer idx = lua_tointeger(L, -2);
-
-                // ignore index less than i
-                if (idx < i) {
-                    lua_pop(L, 1);
-                    continue;
-                }
-
-                // calculate target index on new stack
-                idx = idx - i + 1;
-                if (idx > top && !lua_checkstack(th, idx - top)) {
-                    return luaL_error(L, "too many results to unpack");
-                } else if (idx <= top) {
-                    lua_xmove(L, th, 1);
-                    lua_replace(th, idx);
-                    continue;
-                }
-
-                // fill nils for missing indexes
-                for (int j = top + 1; j < idx; j++) {
-                    lua_pushnil(th);
-                }
-                lua_xmove(L, th, 1);
-                continue;
-            }
-            lua_pop(L, 1);
-        }
-
-        // return results
-        lua_settop(L, 1);
-        n = lua_gettop(th);
-        if (!lua_checkstack(L, n)) {
-            return luaL_error(L, "too many results to unpack");
-        }
-        lua_xmove(th, L, n);
-        return (int)n;
+        return unpack_lj(L, i);
     }
 #endif
 


### PR DESCRIPTION
This pull request refactors the implementation of the `unpack` logic to better support LuaJIT (`LUA_LJDIR`) environments. The main change is the introduction of a specialized function, `unpack_lj`, for handling certain cases when running under LuaJIT, and the reorganization of code to improve clarity and maintainability.

Key changes:

**LuaJIT-specific handling:**

* Introduced a new `unpack_lj` function to handle unpacking when the third argument is not provided in LuaJIT, moving this logic out of the main `unpack_lua` function for better separation and clarity.
* Adjusted the `unpack_lua` function to delegate to `unpack_lj` when running under LuaJIT and the third argument is `nil`, ensuring correct behavior in this environment.

**Code organization and maintainability:**

* Refactored conditional compilation logic to clearly separate LuaJIT-specific code from the general implementation, making the codebase easier to maintain and understand. [[1]](diffhunk://#diff-21b4d18dfc47e3506987bf6223996619dfe26e2ab99c8a8e86ba32c79c240c57L36-L57) [[2]](diffhunk://#diff-21b4d18dfc47e3506987bf6223996619dfe26e2ab99c8a8e86ba32c79c240c57R92-R108)